### PR TITLE
chore: bump standardrb to 1.22.0 in eff-passphrase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@ repos:
     exclude: '^spec/data/'
   - id: check-merge-conflict
 - repo: https://github.com/instrumentl/pre-commit-standardrb.git
-  rev: 'b6b9b2a15f4b721033849181accb8e596d1e8e56'
+  rev: 'b6a9b8ba7657a043448c42ade7114eb8e8282ba5'
   hooks:
     - id: standardrb

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 group :development, :test do
   gem "bundle-audit"
-  gem "standard", "~> 1.21.1"
+  gem "standard", "~> 1.22.0"
   gem "pry", "~> 0.14.1"
   gem "rspec"
   gem "rspec-its"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    standard (1.21.1)
+    standard (1.22.0)
       language_server-protocol (~> 3.17.0.2)
       rubocop (= 1.42.0)
       rubocop-performance (= 1.15.2)
@@ -75,7 +75,7 @@ DEPENDENCIES
   pry (~> 0.14.1)
   rspec
   rspec-its
-  standard (~> 1.21.1)
+  standard (~> 1.22.0)
 
 BUNDLED WITH
    2.4.3


### PR DESCRIPTION
better version of #5 