### PR TITLE
chore: bump rexml to 3.2.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,8 @@ GEM
     racc (1.7.3)
     rainbow (3.1.1)
     regexp_parser (2.8.3)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -74,6 +75,7 @@ GEM
     standard-performance (1.3.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.20.1)
+    strscan (3.1.0)
     thor (1.3.1)
     unicode-display_width (2.5.0)
 


### PR DESCRIPTION
fixes CVE-2024-35176
