### PR TITLE
chore: drop support for ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     steps:
       - name: Checkout code
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: ruby/setup-ruby@cacc9f1c0b3f4eb8a16a6bb0ed10897b43b9de49
         with:
           bundler-cache: true
-          ruby-version: "3.1"
+          ruby-version: "3.3"
       - name: Publish gem
         run: |
           umask 077

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## NEXT
+
+- Drop support for Ruby < 3.0
+
 ## 0.1.1
 
 - Fix gemspec bug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,11 +74,14 @@ GEM
     standard-performance (1.3.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.20.1)
-    thor (1.2.1)
+    thor (1.3.1)
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
+  arm64-darwin-23
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -90,4 +93,4 @@ DEPENDENCIES
   standard (~> 1.33.0)
 
 BUNDLED WITH
-   2.4.3
+   2.5.11

--- a/eff_passphrase.gemspec
+++ b/eff_passphrase.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.homepage = "https://github.com/instrumentl/eff_passphrase"
   spec.license = "ISC"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/instrumentl/eff_passphrase"


### PR DESCRIPTION
other CI (and dependabot) is failing because some of our dependencies (like bundler-audit) have dropped support for ruby 2.7. YAGNI.
