### PR TITLE
fix: add explicit permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Adds explicit `permissions` block to `.github/workflows/release.yml`
- Sets minimal `contents: read` permission following principle of least privilege
- Resolves GitHub code scanning security [alert #2](https://github.com/instrumentl/eff_passphrase/security/code-scanning/2)

## Problem
The release workflow was missing explicit permissions, causing CodeQL to flag it as a security concern (medium severity). Without explicit permissions, the workflow inherits potentially overly-permissive default repository permissions.

## Solution
Added `permissions: contents: read` to the release job. This is the minimal permission required since the workflow only needs to:
- Checkout repository code via `actions/checkout@v6`
- Gem publishing authenticates via `RUBYGEMS_PUSH_API_KEY` secret (external to GitHub)

## References
- Security Alert: https://github.com/instrumentl/eff_passphrase/security/code-scanning/2
- GitHub Docs: [Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs)

## Testing
- ✅ YAML syntax validated
- ✅ Matches pattern used in `ci.yml` and `pull-request-updated.yml`
- ✅ CodeQL should automatically re-scan and close alert once merged

## Checklist
- [x] Minimal permissions applied (contents: read only)
- [x] Follows existing workflow patterns in the repo
- [x] Commit message references security alert
- [x] No breaking changes to workflow functionality